### PR TITLE
[0037]: Explicit Phase Replacement Hooks

### DIFF
--- a/eeps/0037-ekapkgs-explicit-phase-hooks.md
+++ b/eeps/0037-ekapkgs-explicit-phase-hooks.md
@@ -24,10 +24,18 @@ replaced is also not intuitive for many users.
 To reduce the "weirdness budget" of including a dependency, make these hooks
 be specified explicitly.
 
-# Detailed implementation / Specification (optional)
+# Detailed implementation / Specification
 
-See corepkgs#47 for an example for `cmake`. But this would apply to all tools
+See [corepkgs#47](https://github.com/ekala-project/corepkgs/pull/47) for an example for `cmake`. But this would apply to all tools
 which require a configure step.
+
+Example replacement:
+```diff
+  nativeBuildInputs = [
+    cmake
++   cmake.configurePhaseHook
+  ];
+```
 
 # Prior art (optional)
 

--- a/eeps/0037-ekapkgs-explicit-phase-hooks.md
+++ b/eeps/0037-ekapkgs-explicit-phase-hooks.md
@@ -1,0 +1,39 @@
+---
+EEP: 37
+Title: Explicit Phase Hooks
+Author: jonringer
+Status: Provisional
+Type: Standards Track
+Topic: Packaging
+Created: 2025-12-12
+Resolution:
+---
+
+# Motivation
+
+Setup hooks are a quality of life features which interact with the stdenv builder
+in ways which generally alter the build to be more reflective of the expected
+tool. For example, including `cmake` will then automatically change the
+`configurePhase` from the `./configure || true` default configure phase to running
+the equivalent cmake commands to do a `cmake` configure phase. The problem arises
+when these tools are not the entrypoint to a build, the major ecosystem being
+python where some builds will want to invoke meson or cmake, but not have it
+dominate the build logic. The implicit nature of the configure phase being
+replaced is also not intuitive for many users.
+
+To reduce the "weirdness budget" of including a dependency, make these hooks
+be specified explicitly.
+
+# Detailed implementation / Specification (optional)
+
+See corepkgs#47 for an example for `cmake`. But this would apply to all tools
+which require a configure step.
+
+# Prior art (optional)
+
+Unknown
+
+# Future work
+
+- Similar treatment for other tools besides meson and CMake.
+


### PR DESCRIPTION
Require that hooks which replace parts of the stdenv phases be mentioned explicitly. This is to lower the awkardness budget about behavior changing as well as help mitigate complexity when having these tools be invoked by another tool (e.g. python package installation calling into CMake).

Rendered: https://github.com/ekala-project/eeps/blob/explicit-phase-hooks/eeps/0037-ekapkgs-explicit-phase-hooks.md

CMake PR for corepkgs: https://github.com/ekala-project/corepkgs/pull/47